### PR TITLE
React 대시보드 <-> Swift 프로젝트 client-id pairing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to EC2
 
 on:
   push:
-    branches: [ develop, feature/sendData-6 ]
+    branches: [ develop ]
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to EC2
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop, feature/sendData-6 ]
 
 jobs:
   deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# Environment
+.env

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -114,6 +114,20 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -488,6 +502,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -787,6 +811,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,10 @@
       "dependencies": {
         "express": "^5.1.0",
         "ws": "^8.18.2"
+      },
+      "devDependencies": {
+        "cors": "^2.8.5",
+        "uuid": "^11.1.0"
       }
     },
     "node_modules/accepts": {
@@ -121,6 +125,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/debug": {
@@ -497,6 +515,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -796,6 +824,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -20,5 +20,9 @@
   "dependencies": {
     "express": "^5.1.0",
     "ws": "^8.18.2"
+  },
+  "devDependencies": {
+    "cors": "^2.8.5",
+    "uuid": "^11.1.0"
   }
 }

--- a/socket/socket.js
+++ b/socket/socket.js
@@ -1,55 +1,57 @@
 import express from "express";
 import http from "http";
 import { WebSocketServer } from "ws";
+import { v4 as uuidv4 } from "uuid";
+import cors from "cors";
 
 const app = express();
 const port = 8080;
 
-app.get("/", (req, res) => {
+app.use(cors());
+app.get("/client-id", (req, res) => {
+  const clientId = uuidv4();
+  res.json({ clientId });
   res.send("WebSocket 서버 실행 중");
 });
 
 const server = http.createServer(app);
 const wss = new WebSocketServer({ server });
 
+const clientMap = new Map();
+
 wss.on("connection", (ws, req) => {
   console.log("🟢 클라이언트 연결됨:", req.socket.remoteAddress);
 
-  ws.on("message", (message) => {
+  ws.on("message", (data) => {
     try {
-      const messageObj = JSON.parse(message.toString());
+      const message = JSON.parse(data.toString());
+      const { type, clientId } = message;
 
-      if (typeof messageObj.pitch === "number" && typeof messageObj.yaw === "number") {
-        const data = JSON.stringify({
-          type: "motion",
-          pitch: messageObj.pitch,
-          yaw: messageObj.yaw,
-        });
+      if (!clientId) return;
 
-        wss.clients.forEach((client) => {
-          if (client.readyState === WebSocket.OPEN) {
-            client.send(data);
-          }
-        });
-
-        return;
+      if (!clientMap.has(clientId)) {
+        clientMap.set(clientId, {});
       }
 
-      const { name, sliderValue } = messageObj;
-      const value = parseInt(sliderValue, 10);
+      const pair = clientMap.get(clientId);
 
-      if (isNaN(value)) {
-        throw new Error("sliderValue는 숫자가 아닙니다.");
+      if (type === "register-react") {
+        pair.react = ws;
+        console.log("✅ React 연결됨:", clientId);
+      } else if (type === "register-swift") {
+        pair.swift = ws;
+        console.log("✅ Swift 연결됨:", clientId);
       }
 
-      const data = JSON.stringify({ type: "number", name, value });
-      ws.send(data);
+      // motion (Swfit -> React)
+      if (type === "motion" && pair.react) {
+        pair.react.send(JSON.stringify({ type: "motion", pitch: message.pitch, yaw: message.yaw }));
+      }
 
-      wss.clients.forEach(client => {
-        if (client !== ws && client.readyState === WebSocket.OPEN) {
-          client.send(data);
-        }
-      });
+      // control (React -> Swift)
+      if (type === "control" && pair.swift) {
+        pair.swift.send(JSON.stringify({ type: "control", name: message.name, value: message.value }));
+      }
 
     } catch (err) {
       console.error("❌ 메시지 처리 오류:", err.message);

--- a/socket/socket.js
+++ b/socket/socket.js
@@ -10,7 +10,6 @@ app.get("/", (req, res) => {
 });
 
 const server = http.createServer(app);
-
 const wss = new WebSocketServer({ server });
 
 wss.on("connection", (ws, req) => {
@@ -19,6 +18,23 @@ wss.on("connection", (ws, req) => {
   ws.on("message", (message) => {
     try {
       const messageObj = JSON.parse(message.toString());
+
+      if (typeof messageObj.pitch === "number" && typeof messageObj.yaw === "number") {
+        const data = JSON.stringify({
+          type: "motion",
+          pitch: messageObj.pitch,
+          yaw: messageObj.yaw,
+        });
+
+        wss.clients.forEach((client) => {
+          if (client.readyState === WebSocket.OPEN) {
+            client.send(data);
+          }
+        });
+
+        return;
+      }
+
       const { name, sliderValue } = messageObj;
       const value = parseInt(sliderValue, 10);
 


### PR DESCRIPTION
## 📝 요약(Summary)
이슈: #8 
* React 대시보드와 Swift 프로젝트의 client-id를 페어링 할 수 있도록 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

* URL을 통해 접근한 React 대시보드가 사용자 로컬 환경에서 사용 중인 Swift 앱과 연동되게 구현
* Socket 서버에서 client-id를 paring하여 사용자 별로 커스텀하게 서비스를 사용할 수 있도록 구현
* 프론트엔드 단에서 전달받은 uuid를 기반으로 clientId QR 표시가 필요할거 같습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] Swift에서 websocket 서버로 전달하는 데이터와, React에서 전달하는 데이터를 구분하였는가